### PR TITLE
Add CLI instructions for minimal SDK example

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,25 @@ python claude_code_ui.py
 
 You will be prompted for your API key when the application starts.
 
+### Minimal SDK Example
+
+
+The `examples/minimal_async_query.py` script demonstrates how to use the
+[Claude Code Python SDK](https://docs.anthropic.com/en/docs/claude-code/sdk)
+directly. It streams responses asynchronously using `anyio` and relies on the
+Claude Code CLI under the hood. Install the CLI and set your API key first:
+
+```bash
+npm install -g @anthropic-ai/claude-code
+export ANTHROPIC_API_KEY=sk-your-key
+```
+
+Then run the example:
+
+```bash
+python examples/minimal_async_query.py
+```
+
 ## Notes
 
 This is a lightweight proof of concept intended to run inside a local Python environment or a VS Code terminal. It does not implement a full VS Code extension, but demonstrates how a Python UI can integrate with the Claude API. To create a complete VS Code extension you would typically develop in TypeScript/JavaScript and invoke this Python script as needed.

--- a/examples/minimal_async_query.py
+++ b/examples/minimal_async_query.py
@@ -1,0 +1,27 @@
+"""Minimal async example for the Claude Code Python SDK.
+
+This script streams a simple prompt to the Claude Code CLI. It requires:
+
+1. The Claude Code CLI installed via ``npm install -g @anthropic-ai/claude-code``
+2. ``ANTHROPIC_API_KEY`` set in your environment.
+"""
+
+import anyio
+from claude_code_sdk import query, ClaudeCodeOptions, Message
+from claude_code_sdk._errors import CLINotFoundError
+
+async def main() -> None:
+    messages: list[Message] = []
+    async for message in query(
+        prompt="Write a haiku about foo.py",
+        options=ClaudeCodeOptions(max_turns=3),
+    ):
+        messages.append(message)
+
+    print(messages)
+
+if __name__ == "__main__":
+    try:
+        anyio.run(main)
+    except CLINotFoundError as exc:  # pragma: no cover - user facing message
+        print(f"Claude Code CLI not found: {exc}")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,5 @@
 anthropic>=0.54.0
 TkinterDnD2>=0.3.0
+
+claude-code-sdk>=0.0.11
+anyio>=4.0.0


### PR DESCRIPTION
## Summary
- document that the Claude Code CLI is required for the async SDK example
- update README steps for running the example
- add a small docstring and error handler to the example script

## Testing
- `pytest -q`
- `python -m py_compile examples/minimal_async_query.py`
- `python examples/minimal_async_query.py` *(fails: Invalid API key)*

------
https://chatgpt.com/codex/tasks/task_e_68588dd4654c8332ba3fe3923514cb7b